### PR TITLE
Moves core logic into its own package

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,13 @@ $ ./scripts/package.sh
 
 This builds the buildpack's Go source using `GOOS=linux` by default. You can
 supply another value as the first argument to `package.sh`.
+
+## Library Usage
+
+The logic to implement this buildpack is isolated to a package called `logic`, which can be used if you want to incorporate the same logic in  your buildpack or library. This package does reference packit or libcnb/libpak so it can be used from either style buildpack.
+
+```
+import "github.com/paketo-buildpacks/source-removal/logic"
+```
+
+Then you can run `logic.Exclude("foo/*")` or `logic.Include("foo/*")`.

--- a/build.go
+++ b/build.go
@@ -3,20 +3,22 @@ package sourceremoval
 import (
 	"os"
 
+	"github.com/paketo-buildpacks/source-removal/logic"
+
 	"github.com/paketo-buildpacks/packit/v2"
 )
 
 func Build() packit.BuildFunc {
 	return func(context packit.BuildContext) (packit.BuildResult, error) {
 		if includeVal, ok := os.LookupEnv("BP_INCLUDE_FILES"); ok {
-			err := Include(context.WorkingDir, includeVal)
+			err := logic.Include(context.WorkingDir, includeVal)
 			if err != nil {
 				return packit.BuildResult{}, err
 			}
 		}
 
 		if excludeVal, ok := os.LookupEnv("BP_EXCLUDE_FILES"); ok {
-			err := Exclude(context.WorkingDir, excludeVal)
+			err := logic.Exclude(context.WorkingDir, excludeVal)
 			if err != nil {
 				return packit.BuildResult{}, err
 			}

--- a/logic/exclude.go
+++ b/logic/exclude.go
@@ -1,4 +1,4 @@
-package sourceremoval
+package logic
 
 import (
 	"os"

--- a/logic/exclude_test.go
+++ b/logic/exclude_test.go
@@ -1,11 +1,11 @@
-package sourceremoval_test
+package logic_test
 
 import (
 	"os"
 	"path/filepath"
 	"testing"
 
-	sourceremoval "github.com/paketo-buildpacks/source-removal"
+	"github.com/paketo-buildpacks/source-removal/logic"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -44,7 +44,7 @@ func testExclude(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("returns a result that deletes the contents of the working directroy that were specified", func() {
-			err := sourceremoval.Exclude(workingDir, "some-dir/some-other-dir/*:some-file")
+			err := logic.Exclude(workingDir, "some-dir/some-other-dir/*:some-file")
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(workingDir).To(BeADirectory())
@@ -67,14 +67,14 @@ func testExclude(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns an error", func() {
-				err := sourceremoval.Exclude(workingDir, "some-dir/some-other-dir/*:some-file")
+				err := logic.Exclude(workingDir, "some-dir/some-other-dir/*:some-file")
 				Expect(err).To(MatchError(ContainSubstring("permission denied")))
 			})
 		})
 
 		context("when there is a malformed glob in include", func() {
 			it("returns an error", func() {
-				err := sourceremoval.Exclude(workingDir, `\`)
+				err := logic.Exclude(workingDir, `\`)
 				Expect(err).To(MatchError(ContainSubstring("syntax error in pattern")))
 			})
 		})

--- a/logic/include.go
+++ b/logic/include.go
@@ -1,4 +1,4 @@
-package sourceremoval
+package logic
 
 import (
 	"fmt"

--- a/logic/include_test.go
+++ b/logic/include_test.go
@@ -1,11 +1,11 @@
-package sourceremoval_test
+package logic_test
 
 import (
 	"os"
 	"path/filepath"
 	"testing"
 
-	sourceremoval "github.com/paketo-buildpacks/source-removal"
+	"github.com/paketo-buildpacks/source-removal/logic"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -36,7 +36,7 @@ func testInclude(t *testing.T, context spec.G, it spec.S) {
 
 	context("Include", func() {
 		it("returns a result that deletes the contents of the working directroy except for the file that are meant to kept", func() {
-			err := sourceremoval.Include(workingDir, "some-dir/some-other-dir/*:some-file")
+			err := logic.Include(workingDir, "some-dir/some-other-dir/*:some-file")
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(workingDir).To(BeADirectory())
@@ -59,14 +59,14 @@ func testInclude(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns an error", func() {
-				err := sourceremoval.Include(workingDir, "some-dir/some-other-dir/*:some-file")
+				err := logic.Include(workingDir, "some-dir/some-other-dir/*:some-file")
 				Expect(err).To(MatchError(ContainSubstring("permission denied")))
 			})
 		})
 
 		context("when there is a malformed glob in include", func() {
 			it("returns an error", func() {
-				err := sourceremoval.Include(workingDir, `\`)
+				err := logic.Include(workingDir, `\`)
 				Expect(err).To(MatchError(ContainSubstring("syntax error in pattern")))
 			})
 		})

--- a/logic/init_test.go
+++ b/logic/init_test.go
@@ -1,4 +1,4 @@
-package sourceremoval_test
+package logic_test
 
 import (
 	"testing"
@@ -9,7 +9,7 @@ import (
 
 func TestUnitSourceRemoval(t *testing.T) {
 	suite := spec.New("source-removal", spec.Report(report.Terminal{}))
-	suite("Build", testBuild)
-	suite("Detect", testDetect)
+	suite("Exclude", testExclude)
+	suite("Include", testInclude)
 	suite.Run(t)
 }


### PR DESCRIPTION
This PR moves the core Include/Exclude logic into its own package. This allows the core logic to be imported and reused by other buildpacks or libraries. This core logic package does not depend on packit or libcnb/libpak so it can be used in either style buildpack.

Summary:

- Creates 'logic' package (not tied to that name)
- Moves exclude, include and tests into that package
- Updates buildpack & tests to use logic package

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
