### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.7"
 
 [buildpack]
 id = "paketo-buildpacks/source-removal"
-name = "Paketo Source Removal Buildpack"
+name = "Paketo Buildpack for Source Removal"
 
 [metadata]
 include-files = ["bin/run", "bin/build","bin/detect","buildpack.toml"]


### PR DESCRIPTION
Renames 'Paketo Source Removal Buildpack' to 'Paketo Buildpack for Source Removal'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
